### PR TITLE
Ignore CodeQL for Dependabot PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   CodeQL-Build:
-
+    # Don't run for Dependabot since it will fail for push events 
+    if: ${{ github.actor != 'dependabot[bot]' }}  
     # CodeQL runs on ubuntu-latest and windows-latest
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
CodeQL action for Dependabot PRs is failing. Let's ignore that case for now

https://github.com/AstarNetwork/astar.js/actions/runs/5923473228/job/16140854009?pr=56#step:9:47