### PR TITLE
Removed immutable option with yarn

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -28,7 +28,7 @@ jobs:
           GH_RELEASE_GITHUB_API_TOKEN: ${{ secrets.GIT_USER_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          yarn install --immutable | grep -v 'YN0013'
+          yarn install | grep -v 'YN0013'
           yarn ${{ matrix.step }}
 
   dummy:


### PR DESCRIPTION
One month ago workflow didn't work we had PAT authentication problem. This is resolved by creating new PAT with DevopsAstar4everland user token.
       Bump browserify-sign from 4.2.1 to 4.2.2 (#60):
```
$ tsc --build tsconfig.build.json
remote: Personal access tokens (classic) are forbidden from accessing this repository.
fatal: unable to access 'https://github.com/AstarNetwork/astar.js.git/': The requested URL returned error: 403
child_process.js:866
After PAT update, new problem appeared. Updated version in all files (#63):
Run yarn install --immutable | grep -v 'YN0013'
➤ YN0000: ┌ Resolution step
Resolution step
➤ YN0000: └ Completed in 0s 404ms

➤ YN0000: ┌ Post-resolution validation
Post-resolution validation
➤ YN0000: └ Completed
➤ YN0000: Failed with errors in 0s 570ms
Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)
```
I don't think it is related to PAT change. It's unclear to me what suddenly caused error: missing node_modules state file. I checked that Yarn and Node versions in meantime didn't change.
We can only avoid error running yarn install without --immutable option. This will unlock yarn.lock and let installer to create node_modules folder with stat file. 
One more thing, while testing I tried to copy node_modules folder from my local installation, but I think it could be messy.